### PR TITLE
Fix for VideoID problem introduced by previous youtu.be-related change

### DIFF
--- a/TextformatterVideoEmbed.module
+++ b/TextformatterVideoEmbed.module
@@ -103,7 +103,7 @@ class TextformatterVideoEmbed extends Textformatter implements ConfigurableModul
 			if(preg_match_all('#<p>\s*(https?://(www\.)?youtu(.be|be.com)+/(?:watch/?\?v=|v/)?([^\s&<\'"]+)).*?</p>#', $str, $matches)) {
 				foreach($matches[0] as $key => $line) { 
 					$oembedURL = "http://www.youtube.com/oembed?url=" . urlencode($matches[1][$key]) . "&format=json&maxwidth={$this->maxWidth}&maxheight={$this->maxHeight}"; 
-					$videoID = $matches[2][$key]; 
+					$videoID = $matches[4][$key]; 
 					$embedCode = $this->getEmbedCode($oembedURL, $videoID); 
 					if($embedCode) $str = str_replace($line, $embedCode, $str); 
 				}


### PR DESCRIPTION
RegExp changes in previous pull request broke VideoID since array index used for getting it remained unchanged while it should've been updated to reflect other changes. This should fix the problem.

Terribly sorry for that mistake. I'm aware that you've probably already made the fix -- sending this pull request just to make sure.
