### PR TITLE
HTTPS support

### DIFF
--- a/TextformatterVideoEmbed.module
+++ b/TextformatterVideoEmbed.module
@@ -128,8 +128,9 @@ class TextformatterVideoEmbed extends Textformatter implements ConfigurableModul
 
 		foreach($matches[0] as $key => $line) { 
 
+      $protocol = $this->config->https ? "https" : "http";
 			$oembedURL = 
-				"http://www.youtube.com/oembed?url=" . urlencode($matches[1][$key]) . 
+				"$protocol://www.youtube.com/oembed?url=" . urlencode($matches[1][$key]) . 
 				"&format=json&maxwidth={$this->maxWidth}&maxheight={$this->maxHeight}"; 
 
 			$videoID = $matches[2][$key]; 
@@ -161,8 +162,9 @@ class TextformatterVideoEmbed extends Textformatter implements ConfigurableModul
 
 		foreach($matches[0] as $key => $line) { 
 
+      $protocol = $this->config->https ? "https" : "http";
 			$oembedURL = 
-				"http://vimeo.com/api/oembed.json?url=" . urlencode($matches[1][$key]) . 
+				"$protocol://vimeo.com/api/oembed.json?url=" . urlencode($matches[1][$key]) . 
 				"&maxwidth={$this->maxWidth}&maxheight={$this->maxHeight}"; 
 
 			$videoID = $matches[2][$key]; 


### PR DESCRIPTION
When a page is served over HTTPS, the module should serve videos that way. Both YouTube and Vimeo support using SSL connections for Oembed.

The protocol should probably defined globally at init rather than the hacky way I have done it within each function.
