### PR TITLE
Prevent Youtube showing "related videos"

### DIFF
--- a/TextformatterVideoEmbed.module
+++ b/TextformatterVideoEmbed.module
@@ -99,6 +99,7 @@ class TextformatterVideoEmbed extends Textformatter implements ConfigurableModul
 
 			if(is_array($data) && isset($data['html'])) {
 				$embedCode = $data['html'];
+				$embedCode = str_replace('feature=oembed', 'feature=oembed&amp;rel=0', $embedCode);
 
 				$sql = 	"INSERT INTO $table SET " . 
 					"video_id=:videoID, " . 


### PR DESCRIPTION
This change stops YouTube trying to show related videos at the end (which most of the time aren't relevant!) Nwadays YouTube also autoplays the next video too which isn't generally desired.

You could make this optional, but I would suggest the majority of people won't want to show random videos at the end.