### PR TITLE
fix: Allow more recent Vimeo url formats

### DIFF
--- a/TextformatterVideoEmbed.module
+++ b/TextformatterVideoEmbed.module
@@ -510,7 +510,7 @@ class TextformatterVideoEmbed extends Textformatter implements ConfigurableModul
 
 		if(strpos($str, '://vimeo.com/') === false) return;
 
-		if(!preg_match_all('#<(?:p|h[1-6])(?:>|\s+[^>]+>)\s*(https?://vimeo.com/(?:[^<]*?/|)(\d+)).*?</(?:p|h[1-6])>#', $str, $matches)) return;
+		if(!preg_match_all('#<(?:p|h[1-6])(?:>|\s+[^>]+>)\s*(https?://vimeo.com/(?:[^<]*/|)([a-fA-F0-9]+)).*?</(?:p|h[1-6])>#', $str, $matches)) return;
 
 		foreach($matches[0] as $key => $line) {
 			$videoID = $matches[2][$key];


### PR DESCRIPTION
This allows newer Vimeo formats where the ID is now a hex string, not just decimals, and where there can be multiple URL segments before the video id.

Fixes #14 on the [original repo](https://github.com/ryancramerdesign/TextformatterVideoEmbed/issues/14)